### PR TITLE
Set Swift Version Number to 5

### DIFF
--- a/Example/AnimatedGradientView.xcodeproj/project.pbxproj
+++ b/Example/AnimatedGradientView.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -485,6 +486,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
Silences the compiler warning when including the project via CocoaPods.