### PR TITLE
Fixes build issues when using as a Swift Package

### DIFF
--- a/AnimatedGradientView/Classes/AnimatedGradientDirection.swift
+++ b/AnimatedGradientView/Classes/AnimatedGradientDirection.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 @objc public enum AnimatedGradientViewDirection: Int {
     case up

--- a/AnimatedGradientView/Classes/AnimatedGradientView.swift
+++ b/AnimatedGradientView/Classes/AnimatedGradientView.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreGraphics
 import UIKit
 
 public class AnimatedGradientView: UIView {

--- a/AnimatedGradientView/Classes/AnimatedGradientViewAnimation.swift
+++ b/AnimatedGradientView/Classes/AnimatedGradientViewAnimation.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import CoreGraphics
+import QuartzCore
 
 @objc public class AnimatedGradientViewAnimation: NSObject {
     let colorStrings: [String]

--- a/AnimatedGradientView/Classes/AnimatedGradientViewColor.swift
+++ b/AnimatedGradientView/Classes/AnimatedGradientViewColor.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import CoreGraphics
+import CoreImage
+import UIKit
 
 public enum AnimatedGradientViewColor {
     case black

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ From the macOS Terminal run `carthage update --platform iOS` to build the framew
 
 For more information [see here](https://github.com/Carthage/Carthage#quick-start).
 
+### Swift Package Manager
+
+Swift Package Manager is a dependency manager built right into Xcode 11 and higher. From the File menu, add a new Swift Package dependency to your project and paste in this project's Git URL.
+
 ## Usage
 ### Static Gradients
 


### PR DESCRIPTION
It seems Xcode 11 needs frameworks like CoreGraphics to be explicitly imported for Swift Packages to build properly. 

I've gone ahead and imported all the necessary system frameworks in the files where they are used in order to fix the Swift PM experience.

Also added a small blurb in the README about Swift PM... nothing fancy.