### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 
  let package = Package(
      name: "AnimatedGradientView",
-     platforms: [.iOS(.v8)],
+     platforms: [.iOS(.v9)],
      products: [
          .library(name: "AnimatedGradientView", targets: ["AnimatedGradientView"])
      ],


### PR DESCRIPTION
Bumped minimum iOS deployment version from 8 to 9 in order to comply with Xcode 12's minimum deployment range. Fixes compiler warning when installing via SPM.